### PR TITLE
Feature/coupon crud/destroy

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -16,13 +16,15 @@
 
  body {
  background-color: white;
+ font-family: Arial, Helvetica, sans-sans-serif;
+ padding: 20px;
  }
 
  h1 {
   text-align: center;
  	font-size: 40px;
  	color: #002244;
- 	font-family: "Marker Felt", fantasy;
+ 	/* font-family: "Marker Felt", fantasy; */
  }
 
 ul{
@@ -31,6 +33,19 @@ ul{
 }
 img{
   width: 50%;
+}
+
+a:link {
+  text-decoration: none;
+  color: #98AEB3;
+}
+
+a:visited {
+  color: #98AEB3;
+}
+
+a:hover {
+  color: hotpink;
 }
 
 #cart-image{
@@ -56,11 +71,12 @@ section[id*='review'] {
  }
 
  .grid-item{
- 	background-color: #17BEBB;
+ 	background-color: #EFEEEE;
  	padding: 20px;
   border: solid;
  	border-radius: 12px;
-  border-color: #002244;
+  border-color: gray;
+  border-width: 1px;
  	text-align: center
  }
  .item-show-grid{
@@ -78,7 +94,8 @@ section[id*='review'] {
 
  .topnav {
    overflow: hidden;
-   background-color: #002244;
+   background-color: #98AEB3;
+   border-radius: 4px;
  }
 
  .topnav a {
@@ -91,7 +108,7 @@ section[id*='review'] {
  }
 
  .topnav a:hover {
-   background-color: #17BEBB;
+   background-color: hotpink;
    color: black;
  }
 
@@ -131,7 +148,7 @@ section[id*='review'] {
 
 input[type=submit] {
   width: 100%;
-  background-color: #17BEBB;
+  background-color: #999999;
   color: white;
   padding: 14px 20px;
   margin: 8px 0;
@@ -141,7 +158,7 @@ input[type=submit] {
 }
 
 input[type=submit]:hover {
-  background-color: #45a049;
+  background-color: hotpink;
 }
 form {
   align-content: center;
@@ -150,7 +167,7 @@ form {
   width: 60%;
 }
 
-.error-flash {
+/* .error-flash {
   padding: 10px;
   background-color: red;
   color: white;
@@ -159,6 +176,32 @@ form {
   padding: 10px;
   background-color: green;
   color: white;
+} */
+
+.error-flash {
+  color:red;
+  border-color:red;
+}
+
+.success-flash {
+  color:green;
+  border:green;
+}
+
+p.error-flash {
+  border-style: outset;
+  border-color: red;
+  padding: 10px;
+  border-radius: 8px;
+  background-color: #FFCCCB;
+}
+
+p.success-flash {
+  border-style: outset;
+  border-color: green;
+  padding: 10px;
+  border-radius: 8px;
+  background-color: #BFF7df;
 }
 
 table {

--- a/app/controllers/merchant/coupons_controller.rb
+++ b/app/controllers/merchant/coupons_controller.rb
@@ -40,6 +40,13 @@ class Merchant::CouponsController < Merchant::BaseController
     end
   end
 
+  def destroy
+    Coupon.destroy(params[:id])
+    flash[:success] = "Coupon has been deleted."
+    
+    redirect_to merchant_coupons_path
+  end
+
   private
     def coupon_params
       params.require(:coupon).permit(:name, :code, :percent)

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -9,4 +9,7 @@ class Coupon < ApplicationRecord
   validates_numericality_of :percent, greater_than: 0
   validates_numericality_of :percent, less_than_or_equal_to: 100
 
+  def never_applied?
+    orders.empty?
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,10 +42,10 @@
         <%= link_to "Cart: #{cart.total_items}", "/cart" %>
       <% end %>
     </nav>
-    
+
     <% flash.each do |name, msg| %>
       <div class= "<%=name%>-flash">
-        <p><%= msg %></p>
+        <p class = "<%=name%>-flash"><%= msg %></p>
       </div>
     <% end %>
     <%= yield %>

--- a/app/views/merchant/coupons/index.html.erb
+++ b/app/views/merchant/coupons/index.html.erb
@@ -14,6 +14,7 @@
             <p>Code: <%= coupon.code %> </p>
             <p>Discount Percentage: <%= number_to_percentage(coupon.percent, precision: 0) %> </p>
             <center> <%= button_to 'Edit', edit_merchant_coupon_path(coupon.id), method: :get %> </center>
+            <center> <%= button_to 'Delete' %> </center>
         </section>
       <% end %>
     </section>

--- a/app/views/merchant/coupons/index.html.erb
+++ b/app/views/merchant/coupons/index.html.erb
@@ -14,7 +14,7 @@
             <p>Code: <%= coupon.code %> </p>
             <p>Discount Percentage: <%= number_to_percentage(coupon.percent, precision: 0) %> </p>
             <center> <%= button_to 'Edit', edit_merchant_coupon_path(coupon.id), method: :get %> </center>
-            <center> <%= button_to 'Delete' %> </center>
+            <center> <%= button_to 'Delete', merchant_coupon_path(coupon.id), method: :delete %> </center>
         </section>
       <% end %>
     </section>

--- a/app/views/merchant/coupons/index.html.erb
+++ b/app/views/merchant/coupons/index.html.erb
@@ -14,7 +14,9 @@
             <p>Code: <%= coupon.code %> </p>
             <p>Discount Percentage: <%= number_to_percentage(coupon.percent, precision: 0) %> </p>
             <center> <%= button_to 'Edit', edit_merchant_coupon_path(coupon.id), method: :get %> </center>
-            <center> <%= button_to 'Delete', merchant_coupon_path(coupon.id), method: :delete %> </center>
+            <% if coupon.never_applied? %>
+              <center> <%= button_to 'Delete', merchant_coupon_path(coupon.id), method: :delete %> </center>
+            <% end %>
         </section>
       <% end %>
     </section>

--- a/app/views/merchant/coupons/show.html.erb
+++ b/app/views/merchant/coupons/show.html.erb
@@ -3,4 +3,6 @@
   <p><b>Code:</b> <%= @coupon.code %> </p>
   <p><b>Discount Percentage:</b> <%= number_to_percentage(@coupon.percent, precision: 0) %> </p>
   <%= button_to 'Edit', edit_merchant_coupon_path(@coupon.id), method: :get %>
-  <%= button_to 'Delete', merchant_coupon_path(@coupon.id), method: :delete %>
+  <% if @coupon.never_applied? %>
+    <%= button_to 'Delete', merchant_coupon_path(@coupon.id), method: :delete %>
+  <% end %>

--- a/app/views/merchant/coupons/show.html.erb
+++ b/app/views/merchant/coupons/show.html.erb
@@ -3,3 +3,4 @@
   <p><b>Code:</b> <%= @coupon.code %> </p>
   <p><b>Discount Percentage:</b> <%= number_to_percentage(@coupon.percent, precision: 0) %> </p>
   <%= button_to 'Edit', edit_merchant_coupon_path(@coupon.id), method: :get %>
+  <%= button_to 'Delete', merchant_coupon_path(@coupon.id), method: :delete %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,7 +57,7 @@ Rails.application.routes.draw do
     get '/', to: 'dashboard#show'
     resources :orders, only: [:show, :update]
     resources :items, only: [:index, :show, :update, :destroy, :new, :create, :edit]
-    resources :coupons, only: [:index, :show, :new, :create, :edit, :update]
+    resources :coupons, only: [:index, :show, :new, :create, :edit, :update, :destroy]
   end
 
   namespace :admin do

--- a/spec/features/merchant/coupons/destroy_spec.rb
+++ b/spec/features/merchant/coupons/destroy_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+RSpec.describe "As a merchant" do
+  describe "I can delete a coupon if it has not been applied to any orders" do
+    before :each do
+      store = create(:merchant)
+      @merchant = create(:user, role: 1, merchant: store)
+      @coupon_1 = create(:coupon, merchant: store)
+      @coupon_2 = create(:coupon, merchant: store)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+    end
+
+    it "by clicking the delete button next to the coupon from the item index page" do
+      visit merchant_coupons_path
+
+      within "#coupon-#{@coupon_1.id}" do
+        expect(page).to have_link(@coupon_1.name)
+        expect(page).to have_content(@coupon_1.code)
+        expect(page).to have_content("#{@coupon_1.percent}%")
+        expect(page).to have_button("Edit")
+        expect(page).to have_button("Delete")
+      end
+
+      within "#coupon-#{@coupon_2.id}" do
+        expect(page).to have_link(@coupon_2.name)
+        expect(page).to have_content(@coupon_2.code)
+        expect(page).to have_content("#{@coupon_2.percent}%")
+        expect(page).to have_button("Edit")
+        click_button("Delete")
+      end
+
+      expect(current_path).to eq(merchant_coupons_path)
+      expect(page).to have_content("Coupon has been deleted.")
+
+      expect(page).to_not have_css("#coupon-#{@coupon_2.id}")
+      expect(page).to_not have_link(@coupon_2.name)
+      expect(page).to_not have_content(@coupon_2.code)
+      expect(page).to_not have_content("#{@coupon_2.percent}%")
+
+      within "#coupon-#{@coupon_1.id}" do
+        expect(page).to have_link(@coupon_1.name)
+        expect(page).to have_content(@coupon_1.code)
+        expect(page).to have_content("#{@coupon_1.percent}%")
+        expect(page).to have_button("Edit")
+        expect(page).to have_button("Delete")
+      end
+    end
+
+    it "by clicking the delete button from the item show page" do
+      visit merchant_coupons_path
+
+      within "#coupon-#{@coupon_1.id}" do
+        expect(page).to have_link(@coupon_1.name)
+        expect(page).to have_content(@coupon_1.code)
+        expect(page).to have_content("#{@coupon_1.percent}%")
+        expect(page).to have_button("Edit")
+        expect(page).to have_button("Delete")
+      end
+
+      within "#coupon-#{@coupon_2.id}" do
+        expect(page).to have_link(@coupon_2.name)
+        expect(page).to have_content(@coupon_2.code)
+        expect(page).to have_content("#{@coupon_2.percent}%")
+        expect(page).to have_button("Edit")
+        expect(page).to have_button("Delete")
+        click_link @coupon_2.name
+      end
+
+      expect(current_path).to eq(merchant_coupon_path(@coupon_2.id))
+
+      click_button 'Delete'
+
+      expect(current_path).to eq(merchant_coupons_path)
+
+      expect(page).to_not have_css("#coupon-#{@coupon_2.id}")
+      expect(page).to_not have_link(@coupon_2.name)
+      expect(page).to_not have_content(@coupon_2.code)
+      expect(page).to_not have_content("#{@coupon_2.percent}%")
+    end
+  end
+
+  describe "I cannot delete a coupon if it has been applied to an order of any status" do
+    before :each do
+      store = create(:merchant)
+      @merchant = create(:user, role: 1, merchant: store)
+
+      # @user = User.last
+      @order = create(:order)
+
+      @item_1 = create(:item, inventory: 20, merchant: store)
+      @item_2 = create(:item, inventory: 25, merchant: store)
+      @item_3 = create(:item, inventory: 30, merchant: store)
+
+      @order.item_orders.create(item: @item_1, quantity: 2, price: @item_1.price)
+      @order.item_orders.create(item: @item_2, quantity: 1, price: @item_2.price)
+      @order.item_orders.create(item: @item_3, quantity: 3, price: @item_3.price)
+
+      @coupon_1 = create(:coupon, merchant: store)
+      @coupon_2 = create(:coupon, merchant: store)
+
+      @order.coupon = @coupon_1
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+    end
+
+    it "there is no delete button for coupons that have been applied to an order on coupon index" do
+      visit merchant_coupons_path
+
+      within "#coupon-#{@coupon_1.id}" do
+        expect(page).to_not have_button('Delete')
+      end
+
+      within "#coupon-#{@coupon_2.id}" do
+        expect(page).to have_button('Delete')
+      end
+    end
+
+    xit "there is no delete button on a coupon show page if it has been applied to an order" do
+
+    end
+  end
+end

--- a/spec/features/merchant/coupons/destroy_spec.rb
+++ b/spec/features/merchant/coupons/destroy_spec.rb
@@ -80,12 +80,11 @@ RSpec.describe "As a merchant" do
     end
   end
 
-  describe "I cannot delete a coupon if it has been applied to an order of any status" do
+  describe "I cannot delete a coupon if it has been applied to an order" do
     before :each do
       store = create(:merchant)
       @merchant = create(:user, role: 1, merchant: store)
 
-      # @user = User.last
       @order = create(:order)
 
       @item_1 = create(:item, inventory: 20, merchant: store)
@@ -99,7 +98,7 @@ RSpec.describe "As a merchant" do
       @coupon_1 = create(:coupon, merchant: store)
       @coupon_2 = create(:coupon, merchant: store)
 
-      @order.coupon = @coupon_1
+      @coupon_1.orders << @order
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
     end
@@ -116,8 +115,10 @@ RSpec.describe "As a merchant" do
       end
     end
 
-    xit "there is no delete button on a coupon show page if it has been applied to an order" do
+    it "there is no delete button on a coupon show page if it has been applied to an order" do
+      visit merchant_coupon_path(@coupon_1.id)
 
+      expect(page).to_not have_button('Delete')
     end
   end
 end

--- a/spec/features/merchant/coupons/index_spec.rb
+++ b/spec/features/merchant/coupons/index_spec.rb
@@ -24,19 +24,24 @@ RSpec.describe "As a merchant" do
         expect(page).to have_link(@coupon_1.name)
         expect(page).to have_content(@coupon_1.code)
         expect(page).to have_content("#{@coupon_1.percent}%")
+        expect(page).to have_button("Edit")
+        expect(page).to have_button("Delete")
       end
 
       within "#coupon-#{@coupon_2.id}" do
         expect(page).to have_link(@coupon_2.name)
         expect(page).to have_content(@coupon_2.code)
         expect(page).to have_content("#{@coupon_2.percent}%")
-
+        expect(page).to have_button("Edit")
+        expect(page).to have_button("Delete")
       end
 
       within "#coupon-#{@coupon_3.id}" do
         expect(page).to have_link(@coupon_3.name)
         expect(page).to have_content(@coupon_3.code)
         expect(page).to have_content("#{@coupon_3.percent}%")
+        expect(page).to have_button("Edit")
+        expect(page).to have_button("Delete")
       end
     end
 

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -20,4 +20,40 @@ RSpec.describe Coupon do
     # it {should belong_to(:order).optional}
     it {should have_many :orders}
   end
+
+  describe "attributes" do
+    it "has attributes" do
+      merchant = create(:merchant)
+      coupon = Coupon.create!(name: "Winter Sale",
+                              code: "WINTER 2020",
+                              percent: 30,
+                              merchant: merchant)
+
+      expect(coupon.name).to eq("Winter Sale")
+      expect(coupon.code).to eq("WINTER 2020")
+      expect(coupon.percent).to eq(30)
+    end
+  end
+
+  describe "model methods" do
+    describe "#never_applied?" do
+      it "returns true if a coupon has not been applied to an order" do
+        store = create(:merchant)
+        coupon_1 = create(:coupon, merchant: store)
+        coupon_2 = create(:coupon, merchant: store)
+
+        item_1 = create(:item, inventory: 20, merchant: store)
+
+        order = create(:order)
+
+        order.item_orders.create(item: item_1, quantity: 2, price: item_1.price)
+
+        coupon_1.orders << order
+
+        expect(coupon_1.never_applied?).to eq(false)
+        expect(coupon_2.never_applied?).to eq(true)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
**Functionality:**
* Completes crud functionality for coupons with the addition of delete/destroy
* Only coupons that have never been used in an order have a delete button on the index and their show pages, which prevents them from being deleted
* Updated styling on this branch as well

**Testing:**
* Testing at 100%
* Working in devo

**Related Issues:**
* #4 
* #15 
* #16 
