### PR TITLE
Change flash message to indicate coupon has been applied to cart inst…

### DIFF
--- a/app/controllers/coupon_sessions_controller.rb
+++ b/app/controllers/coupon_sessions_controller.rb
@@ -9,7 +9,7 @@ class CouponSessionsController < ApplicationController
       items = Item.find(item_ids)
       if items.any? { |item| item.merchant_id == coupon.merchant_id }
         session[:coupon_id] = coupon.id
-        flash[:success] = "#{coupon.code} has been applied to your order."
+        flash[:success] = "#{coupon.code} has been applied to your cart."
       else
         flash[:error] = "Coupon cannot be applied to your items. Please add items from #{coupon.merchant.name} and re-enter code or try another code."
       end

--- a/spec/features/users/coupons/coupon_application.rb
+++ b/spec/features/users/coupons/coupon_application.rb
@@ -29,7 +29,7 @@ RSpec.describe "As a in user" do
       have_button 'Submit'
     end
 
-    it "if I enter a valid coupon code and click submit I am alerted that coupon is now applied to my order" do
+    it "if I enter a valid coupon code and click submit I am alerted that coupon is now applied to my cart" do
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
 
       visit cart_path
@@ -42,7 +42,7 @@ RSpec.describe "As a in user" do
       end
 
       expect(current_path).to eq(cart_path)
-      expect(page).to have_content("#{@coupon_1.code} has been applied to your order.")
+      expect(page).to have_content("#{@coupon_1.code} has been applied to your cart.")
 
       expect(page).to have_content("Total: $27.00")
       expect(page).to have_content("Discounted Total: $21.60")
@@ -74,7 +74,7 @@ RSpec.describe "As a in user" do
       end
 
       expect(current_path).to eq(cart_path)
-      expect(page).to have_content("#{@coupon_1.code} has been applied to your order.")
+      expect(page).to have_content("#{@coupon_1.code} has been applied to your cart.")
 
       expect(page).to have_content("Total: $57.00")
       expect(page).to have_content("Discounted Total: $51.60")
@@ -128,7 +128,7 @@ RSpec.describe "As a in user" do
         end
 
         expect(current_path).to eq(cart_path)
-        expect(page).to have_content("#{@coupon_1.code} has been applied to your order.")
+        expect(page).to have_content("#{@coupon_1.code} has been applied to your cart.")
 
         expect(page).to have_content("Total: $27.00")
         expect(page).to have_content("Discounted Total: $21.60")
@@ -192,7 +192,7 @@ RSpec.describe "As a in user" do
         click_button 'Submit'
       end
 
-      expect(page).to have_content("#{@coupon_1.code} has been applied to your order.")
+      expect(page).to have_content("#{@coupon_1.code} has been applied to your cart.")
 
       click_link 'Log Out'
 
@@ -213,7 +213,7 @@ RSpec.describe "As a in user" do
       end
 
       visit cart_path
-      expect(page).to_not have_content("#{@coupon_1.code} has been applied to your order.")
+      expect(page).to_not have_content("#{@coupon_1.code} has been applied to your cart.")
     end
   end
 


### PR DESCRIPTION
Functionality:

User can now apply a coupon code to their cart and it is confirmed by a flash message.
The coupon that is applied is saved in a session - not the DB
If the user tries to enter another valid coupon, it will override the last coupon
Users are alerted if they enter a code that is invalid or not good for any of the items they have in their cart (ie they haven't bought anything from the merchant of that coupon). Users are notified via unique flash messages in either case.
Visitors can also apply a coupon to their cart.
If the user logs out, the coupon session is destroyed
Testing:

100% in rspec
Functioning in devo
Related Issues:

#19
#20