### PR TITLE
Extensions/coupon max per merchant

### DIFF
--- a/app/controllers/merchant/coupons_controller.rb
+++ b/app/controllers/merchant/coupons_controller.rb
@@ -15,11 +15,10 @@ class Merchant::CouponsController < Merchant::BaseController
     merchant = Merchant.find(current_user.merchant_id)
     @coupon = merchant.coupons.new(coupon_params)
 
-    if @coupon.save
-      flash[:success] = "Coupon has been added!"
-      redirect_to merchant_coupons_path
+    if merchant.less_than_five_coupons?
+      attempt_coupon_creation(@coupon)
     else
-      flash[:error] = "#{@coupon.errors.full_messages.to_sentence}. Please try again."
+      flash[:error] = "You already have 5 coupons. You must delete a coupon and try again."
       render :new
     end
   end
@@ -43,12 +42,22 @@ class Merchant::CouponsController < Merchant::BaseController
   def destroy
     Coupon.destroy(params[:id])
     flash[:success] = "Coupon has been deleted."
-    
+
     redirect_to merchant_coupons_path
   end
 
   private
     def coupon_params
       params.require(:coupon).permit(:name, :code, :percent)
+    end
+
+    def attempt_coupon_creation(coupon)
+      if coupon.save
+        flash[:success] = "Coupon has been added!"
+        redirect_to merchant_coupons_path
+      else
+        flash[:error] = "#{@coupon.errors.full_messages.to_sentence}. Please try again."
+        render :new
+      end
     end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -8,7 +8,7 @@ class Merchant <ApplicationRecord
   has_many :items, dependent: :destroy
   has_many :item_orders, through: :items
   has_many :users
-  has_many :coupons
+  has_many :coupons, dependent: :destroy
 
   def no_orders?
     item_orders.empty?

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -29,4 +29,8 @@ class Merchant <ApplicationRecord
   def pending_orders
     Order.where(status: "pending").joins(:items).where("items.merchant_id = #{self.id}").distinct
   end
+
+  def less_than_five_coupons?
+    coupons.count < 5
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,8 +9,8 @@
 ItemOrder.destroy_all
 Order.destroy_all
 User.destroy_all
-Coupon.destroy_all
 Merchant.destroy_all
+Coupon.destroy_all
 Item.destroy_all
 #need to add something about destroying coupons... lots of dependencies here!
 

--- a/spec/features/merchant/coupons/new_spec.rb
+++ b/spec/features/merchant/coupons/new_spec.rb
@@ -50,6 +50,8 @@ RSpec.describe "As a merchant I can create a new coupon" do
 
         expect(current_path).to eq(merchant_coupons_path)
         expect(page).to have_content("Coupon has been added!")
+        expect(page).to_not have_content("You already have 5 coupons. You must delete a coupon and try again.")
+
 
         within "#coupon-#{coupon.id}" do
           expect(page).to have_link(name)
@@ -193,6 +195,46 @@ RSpec.describe "As a merchant I can create a new coupon" do
         expect(page).to have_button("Create Coupon")
         expect(page).to have_content("Percent must be less than or equal to 100. Please try again.")
       end
+
+      describe "I can only have 5 coupons in the system" do
+        it "alerts me if I try to add more than 5 coupons" do
+        coupon_1 = Coupon.create!(name: "Winter Blowout",
+                                  code: "WINTER 2020",
+                                  percent: 50,
+                                  merchant: @store)
+
+        coupon_2 = Coupon.create!(name: "Spring Sale",
+                                  code: "SPRING",
+                                  percent: 50,
+                                  merchant: @store)
+
+        coupon_3 = Coupon.create!(name: "Summer Sale ",
+                                  code: "SUMMER  2020",
+                                  percent: 50,
+                                  merchant: @store)
+
+        coupon_4 = Coupon.create!(name: "Fall Sale",
+                                  code: "FALL 2020 ",
+                                  percent: 50,
+                                  merchant: @store)
+
+        coupon_5 = Coupon.create!(name: "Labor Day Sale",
+                                  code: "LABORDAY 2020",
+                                  percent: 50,
+                                  merchant: @store)
+
+        visit new_merchant_coupon_path
+
+        fill_in "Name", with: "Newest Coupon"
+        fill_in "Code", with: "Newest Code"
+        fill_in "Percent", with: 20
+
+        click_button 'Create Coupon'
+
+        expect(page).to have_content("You already have 5 coupons. You must delete a coupon and try again.")
+        expect(page).to have_button('Create Coupon')
+      end
+    end
     end
   end
 end

--- a/spec/features/merchant/coupons/new_spec.rb
+++ b/spec/features/merchant/coupons/new_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "As a merchant I can create a new coupon" do
     end
 
     describe "and click the link to Create New coupon" do
-      it "I can add a new coupon by filling out the form entirely" do
+      it "I can add a new coupon if I have less than 5 coupons by filling out the form entirely" do
         name = "Winter Blowout"
         code = "WINTER 2020"
         percent = 30

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -78,5 +78,19 @@ describe Merchant, type: :model do
 
       expect(@meg.pending_orders).to eq([order_1])
     end
+
+    it 'less_than_five_coupons?' do
+      coupon_1 = create(:coupon, merchant: @meg)
+      coupon_2 = create(:coupon, merchant: @meg)
+      coupon_3 = create(:coupon, merchant: @meg)
+      coupon_4 = create(:coupon, merchant: @meg)
+
+      expect(@meg.less_than_five_coupons?).to eq(true)
+
+      coupon_4 = create(:coupon, merchant: @meg)
+
+      expect(@meg.less_than_five_coupons?).to eq(false)
+
+    end
   end
 end


### PR DESCRIPTION
**Functionality:**
* Limits the number of coupons a merchant can have to 5
* If a merchant employee tries to add a 6th coupon they are alerted via a flash message

**Testing:**
* 100% in RSPEC
* Working in devo 

**Related Issues:**
#36 