### PR TITLE
Extension/merchant can enable disable coupons

### DIFF
--- a/app/controllers/merchant/coupons_controller.rb
+++ b/app/controllers/merchant/coupons_controller.rb
@@ -76,8 +76,10 @@ class Merchant::CouponsController < Merchant::BaseController
     def update_status(coupon)
       if params[:status] == "deactivate"
         coupon.deactivate
+        flash[:success] = "Coupon is unavailable for use."
       elsif params[:status] == "activate"
         coupon.activate
+        flash[:success] = "Coupon is now available for use."
       end
       redirect_to merchant_coupons_path
     end

--- a/app/controllers/merchant/coupons_controller.rb
+++ b/app/controllers/merchant/coupons_controller.rb
@@ -15,10 +15,10 @@ class Merchant::CouponsController < Merchant::BaseController
     merchant = Merchant.find(current_user.merchant_id)
     @coupon = merchant.coupons.new(coupon_params)
 
-    if merchant.less_than_five_coupons?
+    if merchant.less_than_five_active_coupons?
       attempt_coupon_creation(@coupon)
     else
-      flash[:error] = "You already have 5 coupons. You must delete a coupon and try again."
+      flash[:error] = "You already have 5 coupons. You must disable or delete a coupon and try again."
       render :new
     end
   end
@@ -74,9 +74,9 @@ class Merchant::CouponsController < Merchant::BaseController
     end
 
     def update_status(coupon)
-      if params[:status] = "deactivate"
+      if params[:status] == "deactivate"
         coupon.deactivate
-      elsif params[:status] = "activate"
+      elsif params[:status] == "activate"
         coupon.activate
       end
       redirect_to merchant_coupons_path

--- a/app/controllers/merchant/coupons_controller.rb
+++ b/app/controllers/merchant/coupons_controller.rb
@@ -75,9 +75,9 @@ class Merchant::CouponsController < Merchant::BaseController
 
     def update_status(coupon)
       if params[:status] = "deactivate"
-        coupon.toggle!(:active?)
-      else
-        coupon.toggle!(:active?)
+        coupon.deactivate
+      elsif params[:status] = "activate"
+        coupon.activate
       end
       redirect_to merchant_coupons_path
     end

--- a/app/controllers/merchant/coupons_controller.rb
+++ b/app/controllers/merchant/coupons_controller.rb
@@ -28,14 +28,12 @@ class Merchant::CouponsController < Merchant::BaseController
   end
 
   def update
-    @coupon = Coupon.find(params[:format])
-
-    if @coupon.update(coupon_params)
-      flash[:success] = "Coupon has been updated!"
-      redirect_to merchant_coupons_path
+    if info_update?
+      @coupon = Coupon.find(params[:format])
+      attempt_info_update(@coupon)
     else
-      flash[:error] = "#{@coupon.errors.full_messages.to_sentence}. Please try again."
-      render :edit
+      @coupon = Coupon.find(params[:id])
+      update_status(@coupon)
     end
   end
 
@@ -59,5 +57,28 @@ class Merchant::CouponsController < Merchant::BaseController
         flash[:error] = "#{@coupon.errors.full_messages.to_sentence}. Please try again."
         render :new
       end
+    end
+
+    def info_update?
+      params[:status].nil?
+    end
+
+    def attempt_info_update(coupon)
+      if coupon.update(coupon_params)
+        flash[:success] = "Coupon has been updated!"
+        redirect_to merchant_coupons_path
+      else
+        flash[:error] = "#{coupon.errors.full_messages.to_sentence}. Please try again."
+        render :edit
+      end
+    end
+
+    def update_status(coupon)
+      if params[:status] = "deactivate"
+        coupon.toggle!(:active?)
+      else
+        coupon.toggle!(:active?)
+      end
+      redirect_to merchant_coupons_path
     end
 end

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -20,4 +20,9 @@ class Coupon < ApplicationRecord
   def activate
     update(active?: true)
   end
+
+  def status
+    return "Active" if active? == true
+    return "Inactive" if active? == false
+  end
 end

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -12,4 +12,12 @@ class Coupon < ApplicationRecord
   def never_applied?
     orders.empty?
   end
+
+  def deactivate
+    toggle!(:active?)
+  end
+
+  def activate
+    toggle!(:active?)
+  end
 end

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -14,10 +14,10 @@ class Coupon < ApplicationRecord
   end
 
   def deactivate
-    toggle!(:active?)
+    update(active?: false)
   end
 
   def activate
-    toggle!(:active?)
+    update(active?: true)
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -30,7 +30,7 @@ class Merchant <ApplicationRecord
     Order.where(status: "pending").joins(:items).where("items.merchant_id = #{self.id}").distinct
   end
 
-  def less_than_five_coupons?
-    coupons.count < 5
+  def less_than_five_active_coupons?
+    coupons.where(active?: true).count < 5
   end
 end

--- a/app/views/merchant/coupons/index.html.erb
+++ b/app/views/merchant/coupons/index.html.erb
@@ -14,6 +14,12 @@
             <p>Code: <%= coupon.code %> </p>
             <p>Discount Percentage: <%= number_to_percentage(coupon.percent, precision: 0) %> </p>
             <center> <%= button_to 'Edit', edit_merchant_coupon_path(coupon.id), method: :get %> </center>
+            <% if coupon.active? %>
+              <center> <%= button_to 'Disable', merchant_coupon_path(coupon.id), method: :patch, params: {status: "deactivate"} %> </center>
+            <% else %>
+              <center> <%= button_to 'Enable', merchant_coupon_path(coupon.id), method: :patch, params: {status: "activate"} %> </center>
+
+            <% end %>
             <% if coupon.never_applied? %>
               <center> <%= button_to 'Delete', merchant_coupon_path(coupon.id), method: :delete %> </center>
             <% end %>

--- a/app/views/merchant/coupons/index.html.erb
+++ b/app/views/merchant/coupons/index.html.erb
@@ -13,12 +13,12 @@
           <h2> <%=link_to coupon.name, merchant_coupon_path(coupon.id) %> </h2>
             <p>Code: <%= coupon.code %> </p>
             <p>Discount Percentage: <%= number_to_percentage(coupon.percent, precision: 0) %> </p>
+            <p>Status: <%= coupon.status %> </p>
             <center> <%= button_to 'Edit', edit_merchant_coupon_path(coupon.id), method: :get %> </center>
             <% if coupon.active? %>
               <center> <%= button_to 'Disable', merchant_coupon_path(coupon.id), method: :patch, params: {status: "deactivate"} %> </center>
             <% else %>
               <center> <%= button_to 'Enable', merchant_coupon_path(coupon.id), method: :patch, params: {status: "activate"} %> </center>
-
             <% end %>
             <% if coupon.never_applied? %>
               <center> <%= button_to 'Delete', merchant_coupon_path(coupon.id), method: :delete %> </center>

--- a/db/migrate/20200115035459_add_active_to_coupons.rb
+++ b/db/migrate/20200115035459_add_active_to_coupons.rb
@@ -1,0 +1,5 @@
+class AddActiveToCoupons < ActiveRecord::Migration[5.1]
+  def change
+    add_column :coupons, :active?, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200112180232) do
+ActiveRecord::Schema.define(version: 20200115035459) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20200112180232) do
     t.string "code"
     t.integer "percent"
     t.bigint "merchant_id"
+    t.boolean "active?", default: true
     t.index ["merchant_id"], name: "index_coupons_on_merchant_id"
   end
 

--- a/spec/features/merchant/coupons/edit_spec.rb
+++ b/spec/features/merchant/coupons/edit_spec.rb
@@ -164,10 +164,12 @@ RSpec.describe "As a merchant I can edit an existing coupon" do
           end
 
           expect(current_path).to eq(merchant_coupons_path)
+          expect(page).to have_content("Coupon is unavailable for use.")
 
           within "#coupon-#{@coupon_3.id}" do
             expect(page).to_not have_button('Disable')
             expect(page).to have_button('Enable')
+            expect(page).to have_content("Status: Inactive")
           end
         end
       end
@@ -186,10 +188,13 @@ RSpec.describe "As a merchant I can edit an existing coupon" do
           end
 
           expect(current_path).to eq(merchant_coupons_path)
+          expect(page).to have_content("Coupon is now available for use.")
 
           within "#coupon-#{@coupon_3.id}" do
             expect(page).to_not have_button('Enable')
             expect(page).to have_button('Disable')
+            expect(page).to have_content("Status: Active")
+
           end
         end
       end

--- a/spec/features/merchant/coupons/edit_spec.rb
+++ b/spec/features/merchant/coupons/edit_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe "As a merchant I can edit an existing coupon" do
   before :each do
-    store = create(:merchant)
-    @merchant = create(:user, role: 1, merchant: store)
-    @coupon_1 = create(:coupon, merchant: store)
+    @store = create(:merchant)
+    @merchant = create(:user, role: 1, merchant: @store)
+    @coupon_1 = create(:coupon, merchant: @store)
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
   end
@@ -139,6 +139,44 @@ RSpec.describe "As a merchant I can edit an existing coupon" do
 
         expect(page).to have_button("Update Coupon")
         expect(page).to have_content("Percent must be less than or equal to 100. Please try again.")
+      end
+    end
+
+    describe "I can change a coupons status" do
+      before :each do
+        @coupon_2 = create(:coupon, merchant: @store)
+        @coupon_3 = create(:coupon, merchant: @store)
+      end
+
+      describe "from active to inactive" do
+        it "by clicking its disable button" do
+          visit merchant_coupons_path
+
+          within "#coupon-#{@coupon_1.id}" do
+            expect(page).to have_button('Disable')
+          end
+
+          within "#coupon-#{@coupon_2.id}" do
+            expect(page).to have_button('Disable')
+          end
+
+          within "#coupon-#{@coupon_3.id}" do
+            click_button 'Disable'
+          end
+
+          expect(current_path).to eq(merchant_coupons_path)
+
+          within "#coupon-#{@coupon_3.id}" do
+            expect(page).to_not have_button('Disable')
+            expect(page).to have_button('Enable')
+          end
+        end
+      end
+
+      describe "inactive to active" do
+        xit "by clicking its enable button" do
+
+        end
       end
     end
   end

--- a/spec/features/merchant/coupons/edit_spec.rb
+++ b/spec/features/merchant/coupons/edit_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "As a merchant I can edit an existing coupon" do
         fill_in "Percent", with: new_percent
 
         click_button 'Update Coupon'
-#these are pre populated with whatever you tried to answer even if it wasn't acceptable...
+
         expect(find_field('Name').value).to eq(new_name)
         expect(find_field('Code').value).to eq(new_code)
         expect(find_field('Percent').value).to eq("#{new_code}")
@@ -77,7 +77,6 @@ RSpec.describe "As a merchant I can edit an existing coupon" do
       end
 
       it "I am alerted if I try to enter anything except number in the percent field" do
-        # is this really necessary if it's  a form_for number field that actally will NOT let you type a letter in the browser?
         new_percent = "thirty"
 
         visit edit_merchant_coupon_path(@coupon_1.id)

--- a/spec/features/merchant/coupons/edit_spec.rb
+++ b/spec/features/merchant/coupons/edit_spec.rb
@@ -175,16 +175,11 @@ RSpec.describe "As a merchant I can edit an existing coupon" do
 
       describe "inactive to active" do
         it "by clicking its enable button" do
-          @coupon_3.toggle!(:active?)
 
           visit merchant_coupons_path
 
-          within "#coupon-#{@coupon_1.id}" do
-            expect(page).to have_button('Disable')
-          end
-
-          within "#coupon-#{@coupon_2.id}" do
-            expect(page).to have_button('Disable')
+          within "#coupon-#{@coupon_3.id}" do
+            click_button 'Disable'
           end
 
           within "#coupon-#{@coupon_3.id}" do

--- a/spec/features/merchant/coupons/edit_spec.rb
+++ b/spec/features/merchant/coupons/edit_spec.rb
@@ -174,8 +174,29 @@ RSpec.describe "As a merchant I can edit an existing coupon" do
       end
 
       describe "inactive to active" do
-        xit "by clicking its enable button" do
+        it "by clicking its enable button" do
+          @coupon_3.toggle!(:active?)
 
+          visit merchant_coupons_path
+
+          within "#coupon-#{@coupon_1.id}" do
+            expect(page).to have_button('Disable')
+          end
+
+          within "#coupon-#{@coupon_2.id}" do
+            expect(page).to have_button('Disable')
+          end
+
+          within "#coupon-#{@coupon_3.id}" do
+            click_button 'Enable'
+          end
+
+          expect(current_path).to eq(merchant_coupons_path)
+
+          within "#coupon-#{@coupon_3.id}" do
+            expect(page).to_not have_button('Enable')
+            expect(page).to have_button('Disable')
+          end
         end
       end
     end

--- a/spec/features/merchant/coupons/new_spec.rb
+++ b/spec/features/merchant/coupons/new_spec.rb
@@ -50,8 +50,6 @@ RSpec.describe "As a merchant I can create a new coupon" do
 
         expect(current_path).to eq(merchant_coupons_path)
         expect(page).to have_content("Coupon has been added!")
-        expect(page).to_not have_content("You already have 5 coupons. You must delete a coupon and try again.")
-
 
         within "#coupon-#{coupon.id}" do
           expect(page).to have_link(name)
@@ -82,7 +80,6 @@ RSpec.describe "As a merchant I can create a new coupon" do
       end
 
       it "I am alerted if I try to enter anything except number in the percent field" do
-        # is this really necessary if it's  a form_for number field that actally will NOT let you type a letter in the browser?
         name = "Winter Blowout"
         code = "WINTER 2020"
         percent = "thirty"
@@ -196,8 +193,8 @@ RSpec.describe "As a merchant I can create a new coupon" do
         expect(page).to have_content("Percent must be less than or equal to 100. Please try again.")
       end
 
-      describe "I can only have 5 coupons in the system" do
-        it "alerts me if I try to add more than 5 coupons" do
+      describe "I can only have 5 active coupons in the system" do
+        it "alerts me if I try to add a 6th coupon when I have five active" do
         coupon_1 = Coupon.create!(name: "Winter Blowout",
                                   code: "WINTER 2020",
                                   percent: 50,
@@ -231,8 +228,49 @@ RSpec.describe "As a merchant I can create a new coupon" do
 
         click_button 'Create Coupon'
 
-        expect(page).to have_content("You already have 5 coupons. You must delete a coupon and try again.")
+        expect(page).to have_content("You already have 5 coupons. You must disable or delete a coupon and try again.")
         expect(page).to have_button('Create Coupon')
+      end
+
+      it "allows me to add a new coupon if I have 5 total but less than 5 active" do
+        coupon_1 = Coupon.create!(name: "Winter Blowout",
+                                  code: "WINTER 2020",
+                                  percent: 50,
+                                  merchant: @store)
+
+        coupon_2 = Coupon.create!(name: "Spring Sale",
+                                  code: "SPRING",
+                                  percent: 50,
+                                  merchant: @store)
+
+        coupon_3 = Coupon.create!(name: "Summer Sale ",
+                                  code: "SUMMER  2020",
+                                  percent: 50,
+                                  merchant: @store)
+
+        coupon_4 = Coupon.create!(name: "Fall Sale",
+                                  code: "FALL 2020 ",
+                                  percent: 50,
+                                  merchant: @store)
+
+        coupon_5 = Coupon.create!(name: "Labor Day Sale",
+                                  code: "LABORDAY 2020",
+                                  percent: 50,
+                                  merchant: @store,
+                                  active?: false)
+
+        visit new_merchant_coupon_path
+
+        fill_in "Name", with: "Newest Coupon"
+        fill_in "Code", with: "Newest Code"
+        fill_in "Percent", with: 20
+
+        click_button 'Create Coupon'
+
+        expect(current_path).to eq(merchant_coupons_path)
+
+        expect(page).to_not have_content("You already have 5 coupons. You must disable or delete a coupon and try again.")
+        expect(page).to have_content("Coupon has been added!")
       end
     end
     end

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -4,12 +4,11 @@ RSpec.describe Coupon do
   describe "validations" do
     it {should validate_presence_of :name}
     it {should validate_uniqueness_of :name}
-    # this could have a limited number of characters
+
     it {should validate_presence_of :code}
     it {should validate_uniqueness_of :code}
 
     it {should validate_presence_of :percent}
-    #do you need to validate both presence of and numericality of?
     it {should validate_numericality_of(:percent).is_greater_than(0)}
     it {should validate_numericality_of(:percent).is_less_than_or_equal_to(100)}
 
@@ -17,7 +16,6 @@ RSpec.describe Coupon do
 
   describe "relationships" do
     it {should belong_to :merchant}
-    # it {should belong_to(:order).optional}
     it {should have_many :orders}
   end
 
@@ -54,6 +52,27 @@ RSpec.describe Coupon do
         expect(coupon_2.never_applied?).to eq(true)
       end
     end
-  end
 
+    describe "#deactivate" do
+      it "changes a coupons status from active? = true to active? = false" do
+        coupon_1 = create(:coupon)
+
+        coupon_1.deactivate
+
+        expect(coupon_1.active?).to eq(false)
+      end
+    end
+
+    describe "#activate" do
+      it "changes a coupons status from active? = false to active? = true" do
+        coupon_1 = create(:coupon)
+
+        coupon_1.update!(active?: false)
+
+        coupon_1.activate
+
+        expect(coupon_1.active?).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -74,5 +74,15 @@ RSpec.describe Coupon do
         expect(coupon_1.active?).to eq(true)
       end
     end
+
+    describe "#status" do
+      it "returns the coupons status" do
+        coupon_1 = create(:coupon)
+        coupon_2 = create(:coupon, active?: false)
+
+        expect(coupon_1.status).to eq("Active")
+        expect(coupon_2.status).to eq("Inactive")
+      end
+    end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -79,18 +79,21 @@ describe Merchant, type: :model do
       expect(@meg.pending_orders).to eq([order_1])
     end
 
-    it 'less_than_five_coupons?' do
+    it 'less_than_five_active_coupons?' do
       coupon_1 = create(:coupon, merchant: @meg)
       coupon_2 = create(:coupon, merchant: @meg)
       coupon_3 = create(:coupon, merchant: @meg)
       coupon_4 = create(:coupon, merchant: @meg)
 
-      expect(@meg.less_than_five_coupons?).to eq(true)
+      expect(@meg.less_than_five_active_coupons?).to eq(true)
 
-      coupon_4 = create(:coupon, merchant: @meg)
+      coupon_5 = create(:coupon, merchant: @meg, active?: false)
 
-      expect(@meg.less_than_five_coupons?).to eq(false)
+      expect(@meg.less_than_five_active_coupons?).to eq(true)
 
+      coupon_6 = create(:coupon, merchant: @meg)
+
+      expect(@meg.less_than_five_active_coupons?).to eq(false)
     end
   end
 end


### PR DESCRIPTION
**Functionality:**
* Merchants can enable and disable coupons from their coupon index
* Changes previous functionality for limiting merchant coupons to 5 to use active coupons instead of total coupons

**Testing:**
* 100% in RSPEC
* Working in devo 

**Related Issues:**
#38 
#36 